### PR TITLE
Fixed UTF-8 encoding in setup.py for reading README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='hello@micropyramid.com',
     url='https://github.com/MicroPyramid/forex-python',
     description='Foreign exchange rates and currency conversion.',
-    long_description="\n\n".join([open("README.rst").read()]),
+    long_description="\n\n".join([open("README.rst", encoding='utf-8').read()]),
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Caused a problem when installing on Mac OS X.