### PR TITLE
Add basic CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install coveralls
   - pip install pew
 script:
-  - pew toggleglobalsitepackages
+  - yes | pew toggleglobalsitepackages
   - nosetests  --with-coverage --cover-package=forex_python
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ python:
   - "3.4"
   - "3.5"
 
+addons:
+  apt:
+    packages:
+      - python-notify2
+
 install:
   - python setup.py install
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ python:
 addons:
   apt:
     packages:
+      - python3-notify2
       - python-notify2
 
 install:
   - python setup.py install
   - pip install nose
   - pip install coveralls
+  - pip install pew
 script:
+  - pew toggleglobalsitepackages
   - nosetests  --with-coverage --cover-package=forex_python
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       - python3-notify2
       - python-notify2
+      - dbus
 
 install:
   - python setup.py install

--- a/forex_python/__main__.py
+++ b/forex_python/__main__.py
@@ -1,0 +1,62 @@
+"""Command line utilty for forex-python
+=======================================
+
+Inspired by another package: anshulc95/exch
+"""
+import argparse
+import os
+
+from . import converter
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+parser.add_argument(
+    "-b", "--base", default="USD", help="Currency you are converting from."
+)
+parser.add_argument(
+    "-d", "--dest", default="INR", help="Currency you are converting to."
+)
+parser.add_argument(
+    "-a", "--amount", default=1.0, type=float, help="Amount to convert."
+)
+parser.add_argument(
+    "-n", "--notify", action="store_true", help="Display desktop alerts."
+)
+
+
+def conversion_result(amount, base, converted_amount, dest):
+    return "{} {} = {} {}".format(amount, base, converted_amount, dest)
+
+
+def notify_posix(args):
+    try:
+        import notify2
+    except ImportError:
+        print("Requires Linux or macOS with notify2 and dbus package.")
+        raise
+    notify2.init("forex-python")
+    notification = conversion_result(
+        1.0, args.base, converter.get_rate(args.base, args.dest), args.dest
+    )
+    n = notify2.Notification(
+        "forex-python", notification, "notification-message-im"  # Icon name
+    )
+    n.show()
+
+
+def run():
+    args = parser.parse_args()
+    if args.notify:
+        if os.name == "posix":
+            notify_posix(args)
+    else:
+        print(
+            conversion_result(
+                args.amount,
+                args.base,
+                converter.convert(args.base, args.dest, args.amount),
+                args.dest,
+            )
+        )

--- a/forex_python/__main__.py
+++ b/forex_python/__main__.py
@@ -3,8 +3,11 @@
 
 Inspired by another package: anshulc95/exch
 """
+from __future__ import print_function
+
 import argparse
 import os
+import sys
 
 from . import converter
 
@@ -61,8 +64,8 @@ def notify_posix(args):
     n.show()
 
 
-def run():
-    args = parser.parse_args()
+def run(args=None, output=sys.stdout):
+    args = parser.parse_args(args)
     if args.notify:
         if os.name == "posix":
             notify_posix(args)
@@ -73,5 +76,6 @@ def run():
                 args.base,
                 converter.convert(args.base, args.dest, args.amount),
                 args.dest,
-            )
+            ),
+            file=output
         )

--- a/forex_python/__main__.py
+++ b/forex_python/__main__.py
@@ -26,8 +26,22 @@ parser.add_argument(
 )
 
 
-def conversion_result(amount, base, converted_amount, dest):
-    return "{} {} = {} {}".format(amount, base, converted_amount, dest)
+def symbol(currency_code):
+    sym = converter.get_symbol(currency_code)
+    if sym is not None:
+        return sym
+    else:
+        return currency_code
+
+
+def conversion_result(amount, base, converted_amount, dest, use_symbols=False):
+    if use_symbols:
+        return "{} {} = {} {}".format(
+            symbol(base), amount, symbol(dest), converted_amount
+        )
+    else:
+        return "{} {} = {} {}".format(amount, base, converted_amount, dest)
+
 
 
 def notify_posix(args):
@@ -38,7 +52,8 @@ def notify_posix(args):
         raise
     notify2.init("forex-python")
     notification = conversion_result(
-        1.0, args.base, converter.get_rate(args.base, args.dest), args.dest
+        1.0, args.base, converter.get_rate(args.base, args.dest), args.dest,
+        True
     )
     n = notify2.Notification(
         "forex-python", notification, "notification-message-im"  # Icon name

--- a/forex_python/__main__.py
+++ b/forex_python/__main__.py
@@ -69,6 +69,9 @@ def run(args=None, output=sys.stdout):
     if args.notify:
         if os.name == "posix":
             notify_posix(args)
+        else:
+            raise ValueError(
+                "The option [-n] is available only for POSIX operating systems")
     else:
         print(
             conversion_result(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import io
 import os
 from setuptools import setup, find_packages
 
@@ -19,6 +18,17 @@ GitHub: https://github.com/MicroPyramid/forex-python
 
 """
 
+install_requires=[
+    'requests',
+    'simplejson',
+]
+
+if os.name == 'posix':
+    install_requires += [
+        'notify2',
+        'dbus-python'
+    ]
+
 setup(
     name='forex-python',
     version=VERSION,
@@ -29,10 +39,7 @@ setup(
     long_description=long_description_text,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
-    install_requires=[
-        'requests',
-        'simplejson',
-    ],
+    install_requires=install_requires,
     classifiers=[
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Internationalization',
     ],
+    entry_points={
+        'console_scripts':
+        ['forex-python=forex_python.__main__:run']
+    },
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ class TestCLI(unittest.TestCase):
 
     def test_defaults(self):
         with open(os.devnull, "w") as null:
-            run(output=null)
+            run([], output=null)
 
     def test_options(self):
         with open(os.devnull, "w") as null:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,9 @@ class TestCLI(unittest.TestCase):
         with open(os.devnull, "w") as null:
             run([], output=null)
 
+    def test_notify(self):
+        run(["--notify"])
+
     def test_options(self):
         with open(os.devnull, "w") as null:
             run(["-b", "GBP", "-d", "EUR", "-a", "121"], null)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+from forex_python.__main__ import run, symbol
+
+
+class TestCLI(unittest.TestCase):
+    """Test forex-python command-line interface."""
+
+    def test_defaults(self):
+        with open(os.devnull, "w") as null:
+            run(output=null)
+
+    def test_options(self):
+        with open(os.devnull, "w") as null:
+            run(["-b", "GBP", "-d", "EUR", "-a", "121"], null)
+
+    def test_symbol(self):
+        assert symbol("EUR") == u"\u20ac"
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```sh
❯❯❯ forex-python --help                                                     (forex-python-GSe5K8uD) 
usage: forex-python [-h] [-b BASE] [-d DEST] [-a AMOUNT] [-n]

optional arguments:
  -h, --help            show this help message and exit
  -b BASE, --base BASE  Currency you are converting from. (default: USD)
  -d DEST, --dest DEST  Currency you are converting to. (default: INR)
  -a AMOUNT, --amount AMOUNT
                        Amount to convert. (default: 1.0)
  -n, --notify          Display desktop alerts. (default: False)
```