### PR TITLE
Update pip package and module name

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -150,3 +150,4 @@ _CURRENCY_CODES = CurrencyCodes()
 
 get_symbol = _CURRENCY_CODES.get_symbol
 get_currency_name = _CURRENCY_CODES.get_currency_name
+get_currency_code_from_symbol = _CURRENCY_CODES.get_currency_code_from_symbol


### PR DESCRIPTION
I found out that you don't have your changes about getting currency code from symbol, when you download the package via pip `pip install forex-python` . Moreover I think you are missing this lane 

`get_currency_code_from_symbol = _CURRENCY_CODES.get_currency_code_from_symbol`

Sorry if I am mistaken, I am still new to python
