### PR TITLE
Issue #60: ratesapi.io changed to exchangeratesapi.io

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -24,7 +24,7 @@ class Common:
         self._force_decimal = force_decimal
 
     def _source_url(self):
-        return "https://ratesapi.io/api/"
+        return "https://api.exchangeratesapi.io/api/"
 
     def _get_date_string(self, date_obj):
         if date_obj is None:


### PR DESCRIPTION
The URL ratesapi.io has been changed to exchangeratesapi.io. I changed the URL in converter.py and run all the tests positively.