### PR TITLE
Update Russian ruble symbol

### DIFF
--- a/forex_python/raw_data/currencies.json
+++ b/forex_python/raw_data/currencies.json
@@ -117,7 +117,7 @@
   {"cc":"QAR","symbol":"QR","name":"Qatari riyal"},
   {"cc":"RON","symbol":"L","name":"Romanian leu"},
   {"cc":"RSD","symbol":"din.","name":"Serbian dinar"},
-  {"cc":"RUB","symbol":"R","name":"Russian ruble"},
+  {"cc":"RUB","symbol":"\u20bd","name":"Russian ruble"},
   {"cc":"SAR","symbol":"SR","name":"Saudi riyal"},
   {"cc":"SBD","symbol":"SI$","name":"Solomon Islands dollar"},
   {"cc":"SCR","symbol":"SR","name":"Seychellois rupee"},


### PR DESCRIPTION
Currency symbol of The Russian ruble is ₽ (the encoding U+20BD):
https://en.wikipedia.org/wiki/Russian_ruble
https://unicode-table.com/en/20BD/