### PR TITLE
use new API URL

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -24,7 +24,7 @@ class Common:
         self._force_decimal = force_decimal
 
     def _source_url(self):
-        return "https://api.ratesapi.io/api/"
+        return "https://exchangeratesapi.io"
 
     def _get_date_string(self, date_obj):
         if date_obj is None:


### PR DESCRIPTION
Old API URL (apiratesapi.io) seems to have been decommissioned and can no longer be resolved.  A GET on the top level returns an address which works: https://exchangeratesapi.io