### PR TITLE
Made compatible with new exchange rate api

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -102,8 +102,8 @@ class CurrencyRates(Common):
                     "convert requires amount parameter is of type Decimal when force_decimal=True")
         raise RatesNotAvailableError("Currency Rates Source Not Ready")
 
-
-_CURRENCY_FORMATTER = CurrencyRates()
+# Please add your access key here
+_CURRENCY_FORMATTER = CurrencyRates("your_access_key")
 
 get_rates = _CURRENCY_FORMATTER.get_rates
 get_rate = _CURRENCY_FORMATTER.get_rate

--- a/tests/test.py
+++ b/tests/test.py
@@ -102,7 +102,7 @@ class TestForceDecimalAmountConvert(TestCase):
     """
 
     def setUp(self):
-        self.c = CurrencyRates(force_decimal=True)
+        self.c = CurrencyRates("your_access_key", force_decimal=True)
 
     def test_amount_decimal_convert(self):
         amount = self.c.convert('USD', 'INR', Decimal('10.45'))


### PR DESCRIPTION
Note: This is not an optimal change just a hotfix to make the code work

You will need your own access_key which you can get for free after registering with 1000 request limit per month, please provide this key when you create CurrencyCodes as an argument CurrencyCodes(access_key)

Also note that with free tier they don't support HTTPS currently all request will be HTTP based by default

