### PR TITLE
Replace Bitcoin symbol with unicode

### DIFF
--- a/forex_python/raw_data/currencies.json
+++ b/forex_python/raw_data/currencies.json
@@ -20,7 +20,7 @@
   {"cc":"BOB","symbol":"Bs.","name":"Bolivian boliviano"},
   {"cc":"BRL","symbol":"R$","name":"Brazilian real"},
   {"cc":"BSD","symbol":"B$","name":"Bahamian dollar"},
-  {"cc":"BTC","symbol":"₿","name":"Bitcoin"},
+  {"cc":"BTC","symbol":"\u20bf","name":"Bitcoin"},
   {"cc":"BTN","symbol":"Nu.","name":"Bhutanese ngultrum"},
   {"cc":"BWP","symbol":"P","name":"Botswana pula"},
   {"cc":"BYR","symbol":"Br","name":"Belarusian ruble"},


### PR DESCRIPTION
Experiencing an error when using `c.get_symbol("EUR")`

```
  File "/usr/local/lib/python3.8/site-packages/forex_python/converter.py", line 137, in get_symbol
    currency_dict = self._get_data(currency_code)
  File "/usr/local/lib/python3.8/site-packages/forex_python/converter.py", line 125, in _get_data
    currency_data = json.loads(f.read())
  File "/usr/local/lib/python3.8/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1252: ordinal not in range(128)
```