### PR TITLE
Revert "Merge pull request #102 from MicroPyramid/Currency_Rates_Source_Not_Ready"

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -37,8 +37,9 @@ class Common:
             decoded_data = json.loads(response.text, use_decimal=True)
         else:
             decoded_data = response.json()
-        # if (date_str and date_str != 'latest' and date_str != decoded_data.get('date')):
-        #     raise RatesNotAvailableError("Currency Rates Source Not Ready")
+        if (date_str and date_str != 'latest'
+                and date_str != decoded_data.get('date')):
+            raise RatesNotAvailableError("Currency Rates Source Not Ready")
         return decoded_data.get('rates', {})
 
     def _get_decoded_rate(


### PR DESCRIPTION
This reverts commit 0ca3addfaca7d81bc3da037578460278c10d8f1c, reversing changes made to fcc62b71588519b7b3a73a0b8ede7745a2dcb7b6.

The reverted commit prevented the `RatesNotAvailableError` from being raised
Causing two unit tests to fail on the master branch
`TestGetRate.test_get_rates_in_future` and `TestGetRates.test_get_rates_in_future`