### PR TITLE
Specify utf-8 as the encoding for currencies.json

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -124,7 +124,7 @@ class CurrencyCodes:
     def _currency_data(self):
         if self.__currency_data is None:
             file_path = os.path.dirname(os.path.abspath(__file__))
-            with open(file_path + '/raw_data/currencies.json') as f:
+            with open(file_path + '/raw_data/currencies.json', encoding='utf-8') as f:
                 self.__currency_data = json.loads(f.read())
         return self.__currency_data
 


### PR DESCRIPTION
This is a fix for issue: "Attempt to read /raw_data/currencies.json as ascii instead of utf-8 breaks get_symbol()" - https://github.com/MicroPyramid/forex-python/issues/109

We tell the file reader the encoding of `/raw_data/currencies.json` instead of using python auto detection.