### PR TITLE
Remove GQE currency

### DIFF
--- a/forex_python/raw_data/currencies.json
+++ b/forex_python/raw_data/currencies.json
@@ -52,7 +52,6 @@
   {"cc":"GIP","symbol":"\u00a3","name":"Gibraltar pound"},
   {"cc":"GMD","symbol":"D","name":"Gambian dalasi"},
   {"cc":"GNF","symbol":"FG","name":"Guinean franc"},
-  {"cc":"GQE","symbol":"CFA","name":"Central African CFA franc"},
   {"cc":"GTQ","symbol":"Q","name":"Guatemalan quetzal"},
   {"cc":"GYD","symbol":"GY$","name":"Guyanese dollar"},
   {"cc":"HKD","symbol":"HK$","name":"Hong Kong dollar"},


### PR DESCRIPTION
Currency with code GQE has duplicate symbol and name, with XAF currency
Can't find currency code GQE on forex so removing