### PR TITLE
Remove & update obsolete link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ The rates are updated daily 3PM CET.
 
 BitCoin Price Source:
 ---------------------
-Bitcoin prices calculated every minute. For more information visit [CoinDesk API](http://www.coindesk.com/api/).
+Bitcoin prices calculated every minute. For more information visit [CoinDesk](http://www.coindesk.com).
 
 Installation
 --------------


### PR DESCRIPTION
precedent link: https://www.coindesk.com/tag/api/ leads to /error/404, therefore it is preferable to change it to the main page of coindesk