### PR TITLE
Stop waiting forever when "currency not ready"

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -55,7 +55,7 @@ class CurrencyRates(Common):
         date_str = self._get_date_string(date_obj)
         payload = {'base': base_cur, 'rtype': 'fpy'}
         source_url = self._source_url() + date_str
-        response = requests.get(source_url, params=payload)
+        response = requests.get(source_url, params=payload, timeout=5)
         if response.status_code == 200:
             rates = self._decode_rates(response, date_str=date_str)
             return rates
@@ -69,7 +69,7 @@ class CurrencyRates(Common):
         date_str = self._get_date_string(date_obj)
         payload = {'base': base_cur, 'symbols': dest_cur, 'rtype': 'fpy'}
         source_url = self._source_url() + date_str
-        response = requests.get(source_url, params=payload)
+        response = requests.get(source_url, params=payload, timeout=5)
         if response.status_code == 200:
             rate = self._get_decoded_rate(response, dest_cur, date_str=date_str)
             if not rate:
@@ -92,7 +92,7 @@ class CurrencyRates(Common):
         date_str = self._get_date_string(date_obj)
         payload = {'base': base_cur, 'symbols': dest_cur, 'rtype': 'fpy'}
         source_url = self._source_url() + date_str
-        response = requests.get(source_url, params=payload)
+        response = requests.get(source_url, params=payload, timeout=5)
         if response.status_code == 200:
             rate = self._get_decoded_rate(
                 response, dest_cur, use_decimal=use_decimal, date_str=date_str)


### PR DESCRIPTION
the problem:
when the url is down, the library waits just about forever for the response that's doomed to fail. i highly suspect this is the cause of all the "currency not ready" issues here. it could literarily be like a minute.

the fix:
wait only 5 seconds instead. (this is just a random number i came up with. feel free to change it to something else that suits your need better.)

detailed explanation of why this is a good thing to do
https://datagy.io/python-requests-timeouts/