### PR TITLE
Update converter.py

### DIFF
--- a/forex_python/converter.py
+++ b/forex_python/converter.py
@@ -124,7 +124,7 @@ class CurrencyCodes:
     def _currency_data(self):
         if self.__currency_data is None:
             file_path = os.path.dirname(os.path.abspath(__file__))
-            with open(file_path + '/raw_data/currencies.json') as f:
+            with open(file_path + '/raw_data/currencies.json', encoding="utf-8") as f:
                 self.__currency_data = json.loads(f.read())
         return self.__currency_data
 


### PR DESCRIPTION
added utf-8 encoding when opening curriencies.json. otherwise exception type: unicodedecodeerror exception value: 'ascii' codec can't decode byte 0xc3 in position 7400: ordinal not in range(128) in ubuntu server